### PR TITLE
E

### DIFF
--- a/.github/workflows/buildjre17.yml
+++ b/.github/workflows/buildjre17.yml
@@ -13,14 +13,10 @@ jobs:
       fail-fast: false
 
     name: "Build for Android ${{matrix.arch}}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.4
-    - name: set up python 3.12.3
-      uses: actions/setup-python@v5.1.0
-      with:
-        python-version: '3.12.3'
     - name: set up JDK 17
       uses: actions/setup-java@v4.2.1
       with:
@@ -53,7 +49,7 @@ jobs:
 
   pojav:
     needs: build_android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.4

--- a/.github/workflows/buildjre21.yml
+++ b/.github/workflows/buildjre21.yml
@@ -13,14 +13,10 @@ jobs:
       fail-fast: false
 
     name: "Build for Android ${{matrix.arch}}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.4
-    - name: set up python 3.12.3
-      uses: actions/setup-python@v5.1.0
-      with:
-        python-version: '3.12.3'
     - name: set up JDK 21
       uses: actions/setup-java@v4.2.1
       with:
@@ -53,7 +49,7 @@ jobs:
 
   pojav:
     needs: build_android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.4

--- a/.github/workflows/buildjre8.yml
+++ b/.github/workflows/buildjre8.yml
@@ -17,15 +17,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.4
-    - name: set up python 3.12.3
-      uses: actions/setup-python@v5.1.0
-      with:
-        python-version: '3.12.3'
-    - name: Set Up JDK 1.7
+    - name: Set Up JDK 8
       uses: actions/setup-java@v4.2.1
       with:
-        java-version: 7
-        distribution: zulu
+        java-version: 8
+        distribution: temurin
     - name: Install build dependencies
       run: |
         sudo apt update


### PR DESCRIPTION
1.通过更新ubuntu版本来更新默认ndk的版本
2.去除set up python(自带)
3.用回jdk8来build java8(原因:1.吸取java11 build失败经验 2.azul也用jdk8来build)

等待https://github.com/aaaapai/android-openjdk-autobuild/actions/runs/9810357093 build成功即可合并(jdk17,21 build成功过，不再重复build，jdk11未作出修改，无需重复build)